### PR TITLE
#93-task-2,3 S3 접근 권한 획득 API

### DIFF
--- a/src/docs/asciidoc/api/media.adoc
+++ b/src/docs/asciidoc/api/media.adoc
@@ -1,4 +1,5 @@
 [[media-page]]
+
 === 신규 미디어 등록
 ==== HTTP Request
 include::{snippets}/media-create/http-request.adoc[]
@@ -44,3 +45,23 @@ include::{snippets}/media-delete/path-parameters.adoc[]
 include::{snippets}/media-delete/request-headers.adoc[]
 ==== HTTP Response
 include::{snippets}/media-delete/http-response.adoc[]
+---
+=== 미디어 업로드 권한 요청
+private s3 upload를 위한 임시 access token 요청 API입니다.
+
+발급된 토큰은 900초(15분) 간 유효합니다.
+
+해당 토큰과 함께 반환된 bucket과 key에 해당하는 s3 resource에만 업로드가 가능합니다.
+
+미디어, 썸네일 업로드 이후 해당 url을 사용해<<신규 미디어 등록>>요청을 해주세요.
+
+==== HTTP Request
+include::{snippets}/media-upload-token/http-request.adoc[]
+==== Request Parameters
+include::{snippets}/media-upload-token/query-parameters.adoc[]
+==== Request Headers
+include::{snippets}/media-upload-token/request-headers.adoc[]
+
+==== HTTP Response
+include::{snippets}/media-upload-token/http-response.adoc[]
+include::{snippets}/media-upload-token/response-fields.adoc[]

--- a/src/main/java/swm/s3/coclimb/CoclimbApplication.java
+++ b/src/main/java/swm/s3/coclimb/CoclimbApplication.java
@@ -3,16 +3,14 @@ package swm.s3.coclimb;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import swm.s3.coclimb.config.propeties.AwsCredentialsProperties;
-import swm.s3.coclimb.config.propeties.AwsRdsProperties;
-import swm.s3.coclimb.config.propeties.ElasticProperties;
-import swm.s3.coclimb.config.propeties.JwtProperties;
+import swm.s3.coclimb.config.propeties.*;
 
 @EnableConfigurationProperties({
 		JwtProperties.class,
 		ElasticProperties.class,
 		AwsRdsProperties.class,
-		AwsCredentialsProperties.class
+		AwsCredentialsProperties.class,
+		AwsS3MediaProperties.class
 })
 @SpringBootApplication
 public class CoclimbApplication {

--- a/src/main/java/swm/s3/coclimb/api/adapter/in/web/media/MediaController.java
+++ b/src/main/java/swm/s3/coclimb/api/adapter/in/web/media/MediaController.java
@@ -13,6 +13,7 @@ import swm.s3.coclimb.api.application.port.in.media.MediaCommand;
 import swm.s3.coclimb.api.application.port.in.media.MediaQuery;
 import swm.s3.coclimb.api.application.port.in.media.dto.MediaDeleteRequestDto;
 import swm.s3.coclimb.api.application.port.in.media.dto.MediaPageRequestDto;
+import swm.s3.coclimb.api.application.port.out.aws.dto.S3AccessToken;
 import swm.s3.coclimb.api.exception.FieldErrorType;
 import swm.s3.coclimb.api.exception.errortype.ValidationFail;
 import swm.s3.coclimb.config.argumentresolver.LoginUser;
@@ -109,5 +110,14 @@ public class MediaController {
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping("/medias/access-token")
+    public ResponseEntity<S3AccessTokenResponse> getMediaAccessToken(@LoginUser User user) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(S3AccessTokenResponse.of(
+                        mediaCommand.createTokenForUpload("coclimb-media-bucket", "media", user.getId())));
+
     }
 }

--- a/src/main/java/swm/s3/coclimb/api/adapter/in/web/media/dto/S3AccessTokenResponse.java
+++ b/src/main/java/swm/s3/coclimb/api/adapter/in/web/media/dto/S3AccessTokenResponse.java
@@ -1,0 +1,38 @@
+package swm.s3.coclimb.api.adapter.in.web.media.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import swm.s3.coclimb.api.application.port.out.aws.dto.S3AccessToken;
+
+@Getter
+@NoArgsConstructor
+public class S3AccessTokenResponse {
+    private String accessKey;
+    private String secretKey;
+    private String sessionToken;
+    private String bucket;
+    private String key;
+
+    @Builder
+    public S3AccessTokenResponse(String accessKey, String secretKey, String sessionToken, String bucket, String key) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.sessionToken = sessionToken;
+        this.bucket = bucket;
+        this.key = key;
+    }
+
+    public static S3AccessTokenResponse of(S3AccessToken s3AccessToken) {
+        Credentials credentials = s3AccessToken.getCredentials();
+        return S3AccessTokenResponse.builder()
+                .accessKey(credentials.accessKeyId())
+                .secretKey(credentials.secretAccessKey())
+                .sessionToken(credentials.sessionToken())
+                .bucket(s3AccessToken.getBucket())
+                .key(s3AccessToken.getKey())
+                .build();
+    }
+
+}

--- a/src/main/java/swm/s3/coclimb/api/adapter/out/aws/AwsS3Manager.java
+++ b/src/main/java/swm/s3/coclimb/api/adapter/out/aws/AwsS3Manager.java
@@ -55,4 +55,9 @@ public class AwsS3Manager implements AwsS3UpdatePort {
             throw new LocalFileDeleteFail();
         }
     }
+
+    @Override
+    public String getCloudFrontUrl(String url) {
+        return cloudFrontHost + url;
+    }
 }

--- a/src/main/java/swm/s3/coclimb/api/adapter/out/aws/AwsSTSManager.java
+++ b/src/main/java/swm/s3/coclimb/api/adapter/out/aws/AwsSTSManager.java
@@ -16,7 +16,8 @@ public class AwsSTSManager{
     private final StsClient stsClient;
     private final AwsS3MediaProperties mediaProperties;
 
-    public Credentials getUploadCredentials(String policy) {
+    public Credentials getCredentials(String bucket, String key, String action) {
+        String policy = generatePolicy(bucket, key, action);
         return stsClient.assumeRole(getAssumeRoleRequest(
                         mediaProperties.getWriteRoleArn(),
                         "temp-upload-session",
@@ -24,7 +25,6 @@ public class AwsSTSManager{
                         policy))
                 .credentials();
     }
-
 
     private AssumeRoleRequest getAssumeRoleRequest(String roleArn, String roleSessionName, Integer validTime, String policy) {
         AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
@@ -40,7 +40,7 @@ public class AwsSTSManager{
         return String.format("%s/%s/%s", prefix, userId.toString(), UUID.randomUUID());
     }
 
-    public String generatePolicy(String bucket, String key, String action) {
+    private String generatePolicy(String bucket, String key, String action) {
         String resourceArn = String.format("arn:aws:s3:::%s/%s", bucket, key);
         String policy = "{\n" +
                 "    \"Version\": \"2012-10-17\",\n" +

--- a/src/main/java/swm/s3/coclimb/api/adapter/out/aws/AwsSTSManager.java
+++ b/src/main/java/swm/s3/coclimb/api/adapter/out/aws/AwsSTSManager.java
@@ -1,0 +1,61 @@
+package swm.s3.coclimb.api.adapter.out.aws;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import swm.s3.coclimb.config.propeties.AwsS3MediaProperties;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class AwsSTSManager{
+
+    private final StsClient stsClient;
+    private final AwsS3MediaProperties mediaProperties;
+
+    public Credentials getUploadCredentials(String policy) {
+        return stsClient.assumeRole(getAssumeRoleRequest(
+                        mediaProperties.getWriteRoleArn(),
+                        "temp-upload-session",
+                        mediaProperties.getWriteValidTime(),
+                        policy))
+                .credentials();
+    }
+
+
+    private AssumeRoleRequest getAssumeRoleRequest(String roleArn, String roleSessionName, Integer validTime, String policy) {
+        AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
+                .roleArn(roleArn)
+                .roleSessionName(roleSessionName)
+                .durationSeconds(validTime) // AWS Default minimum value = 900sec
+                .policy(policy)
+                .build();
+        return assumeRoleRequest;
+    }
+
+    public String generateKey(String prefix, Long userId) {
+        return String.format("%s/%s/%s", prefix, userId.toString(), UUID.randomUUID());
+    }
+
+    public String generatePolicy(String bucket, String key, String action) {
+        String resourceArn = String.format("arn:aws:s3:::%s/%s", bucket, key);
+        String policy = "{\n" +
+                "    \"Version\": \"2012-10-17\",\n" +
+                "    \"Statement\": [\n" +
+                "        {\n" +
+                "            \"Effect\": \"Allow\",\n" +
+                "            \"Action\": [\n" +
+                "                \"s3:"+action+"\"\n" +
+                "            ],\n" +
+                "            \"Resource\": \""+resourceArn+"\"\n" +
+                "        }\n" +
+                "    ]\n" +
+                "}";
+
+        return policy;
+    }
+
+}

--- a/src/main/java/swm/s3/coclimb/api/adapter/out/aws/dto/S3AccessToken.java
+++ b/src/main/java/swm/s3/coclimb/api/adapter/out/aws/dto/S3AccessToken.java
@@ -1,0 +1,29 @@
+package swm.s3.coclimb.api.adapter.out.aws.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+@NoArgsConstructor
+@Getter
+public class S3AccessToken {
+    String bucket;
+    String key;
+    Credentials credentials;
+
+    @Builder
+    public S3AccessToken(String bucket, String key, Credentials credentials) {
+        this.bucket = bucket;
+        this.key = key;
+        this.credentials = credentials;
+    }
+
+    public static S3AccessToken of(String bucket, String key, Credentials credentials) {
+        return S3AccessToken.builder()
+                .bucket(bucket)
+                .key(key)
+                .credentials(credentials)
+                .build();
+    }
+}

--- a/src/main/java/swm/s3/coclimb/api/application/port/in/media/MediaCommand.java
+++ b/src/main/java/swm/s3/coclimb/api/application/port/in/media/MediaCommand.java
@@ -3,10 +3,13 @@ package swm.s3.coclimb.api.application.port.in.media;
 import swm.s3.coclimb.api.application.port.in.media.dto.MediaCreateRequestDto;
 import swm.s3.coclimb.api.application.port.in.media.dto.MediaDeleteRequestDto;
 import swm.s3.coclimb.api.application.port.in.media.dto.MediaUpdateRequestDto;
+import swm.s3.coclimb.api.application.port.out.aws.dto.S3AccessToken;
 
 public interface MediaCommand {
     void createMedia(MediaCreateRequestDto mediaCreateRequestDto);
 
     void updateMedia(MediaUpdateRequestDto mediaUpdateRequestDto);
     void deleteMedia(MediaDeleteRequestDto mediaDeleteRequestDto);
+
+    S3AccessToken createTokenForUpload(String bucket, String prefix, Long userId);
 }

--- a/src/main/java/swm/s3/coclimb/api/application/port/in/media/MediaCommand.java
+++ b/src/main/java/swm/s3/coclimb/api/application/port/in/media/MediaCommand.java
@@ -11,5 +11,5 @@ public interface MediaCommand {
     void updateMedia(MediaUpdateRequestDto mediaUpdateRequestDto);
     void deleteMedia(MediaDeleteRequestDto mediaDeleteRequestDto);
 
-    S3AccessToken createTokenForUpload(String bucket, String prefix, Long userId);
+    S3AccessToken createS3AccessToken(String bucket, String prefix, Long userId, String action);
 }

--- a/src/main/java/swm/s3/coclimb/api/application/port/out/aws/AwsS3UpdatePort.java
+++ b/src/main/java/swm/s3/coclimb/api/application/port/out/aws/AwsS3UpdatePort.java
@@ -6,4 +6,6 @@ public interface AwsS3UpdatePort {
     String uploadFile(DownloadedFileDetail fileDetail);
 
     void deleteFile(String fileUrl);
+
+    String getCloudFrontUrl(String url);
 }

--- a/src/main/java/swm/s3/coclimb/api/application/port/out/aws/dto/S3AccessToken.java
+++ b/src/main/java/swm/s3/coclimb/api/application/port/out/aws/dto/S3AccessToken.java
@@ -1,0 +1,29 @@
+package swm.s3.coclimb.api.application.port.out.aws.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+@NoArgsConstructor
+@Getter
+public class S3AccessToken {
+    String bucket;
+    String key;
+    Credentials credentials;
+
+    @Builder
+    public S3AccessToken(String bucket, String key, Credentials credentials) {
+        this.bucket = bucket;
+        this.key = key;
+        this.credentials = credentials;
+    }
+
+    public static S3AccessToken of(String bucket, String key, Credentials credentials) {
+        return S3AccessToken.builder()
+                .bucket(bucket)
+                .key(key)
+                .credentials(credentials)
+                .build();
+    }
+}

--- a/src/main/java/swm/s3/coclimb/config/propeties/AwsS3MediaProperties.java
+++ b/src/main/java/swm/s3/coclimb/config/propeties/AwsS3MediaProperties.java
@@ -1,0 +1,20 @@
+package swm.s3.coclimb.config.propeties;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "aws-config.s3.media")
+public class AwsS3MediaProperties {
+    private final String writeRoleArn;
+    private final Integer writeValidTime;
+    private final String readRoleArn;
+    private final Integer readValidTime;
+
+    public AwsS3MediaProperties(String writeRoleArn, Integer writeValidTime, String readRoleArn, Integer readValidTime) {
+        this.writeRoleArn = writeRoleArn;
+        this.writeValidTime = writeValidTime;
+        this.readRoleArn = readRoleArn;
+        this.readValidTime = readValidTime;
+    }
+}

--- a/src/main/java/swm/s3/coclimb/config/security/JwtManager.java
+++ b/src/main/java/swm/s3/coclimb/config/security/JwtManager.java
@@ -16,12 +16,12 @@ public class JwtManager {
 //    private final AppConfig appConfig;
     private final ServerClock serverClock;
     private final JwtParser jwtParser;
-    private final JwtProperties jwt;
+    private final JwtProperties jwtProperties;
 
     public JwtManager(AppConfig appConfig, ServerClock serverClock) {
-        jwt = appConfig.getJwtProperties();
+        jwtProperties = appConfig.getJwtProperties();
         this.serverClock = serverClock;
-        this.jwtParser = Jwts.parserBuilder().setSigningKey(jwt.getSecretKey()).build();
+        this.jwtParser = Jwts.parserBuilder().setSigningKey(jwtProperties.getSecretKey()).build();
     }
 
     public String issueToken(String subject) {
@@ -31,8 +31,8 @@ public class JwtManager {
                 .setSubject(subject)
                 .setAudience("all")
                 .setIssuedAt(iat)
-                .setExpiration(new Date(iat.getTime() + jwt.getValidTime()))//만료시간 - ms단위;1000=1초
-                .signWith(jwt.getSecretKey())
+                .setExpiration(new Date(iat.getTime() + jwtProperties.getValidTime()))//만료시간 - ms단위;1000=1초
+                .signWith(jwtProperties.getSecretKey())
                 .compact();
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,12 @@ aws-config:
   credentials:
     access_key: ${secret.aws.access_key}
     secret_key: ${secret.aws.secret_key}
-
+  s3:
+    media:
+      write_role_arn: "arn:aws:iam::085796513949:role/CoclimbS3Access"
+      write_valid_time: 900 # sec
+      read_role_arn: "arn:aws:iam::085796513949:role/CoclimbS3ReadOnly"
+      read_valid_time: 3600 # sec
 
 cloud:
   aws:

--- a/src/test/java/swm/s3/coclimb/api/IntegrationTestSupport.java
+++ b/src/test/java/swm/s3/coclimb/api/IntegrationTestSupport.java
@@ -1,6 +1,10 @@
 package swm.s3.coclimb.api;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -8,7 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import software.amazon.awssdk.services.sts.model.Credentials;
 import swm.s3.coclimb.api.adapter.out.aws.AwsS3Manager;
+import swm.s3.coclimb.api.adapter.out.aws.AwsSTSManager;
 import swm.s3.coclimb.api.adapter.out.persistence.gym.GymDocumentRepository;
 import swm.s3.coclimb.api.adapter.out.filedownload.FileDownloader;
 import swm.s3.coclimb.api.adapter.out.instagram.InstagramOAuthRecord;
@@ -27,6 +33,7 @@ import swm.s3.coclimb.api.adapter.out.persistence.user.UserDocumentRepository;
 import swm.s3.coclimb.api.adapter.out.persistence.user.UserJpaRepository;
 import swm.s3.coclimb.api.adapter.out.persistence.user.UserRepository;
 import swm.s3.coclimb.api.application.service.*;
+import swm.s3.coclimb.api.exception.errortype.aws.S3UploadFail;
 import swm.s3.coclimb.config.AppConfig;
 import swm.s3.coclimb.config.ServerClock;
 import swm.s3.coclimb.config.security.JwtManager;
@@ -114,6 +121,8 @@ public abstract class IntegrationTestSupport {
     protected AwsS3Manager awsS3Manager;
     @Autowired
     protected FileDownloader fileDownloader;
+    @Autowired
+    protected AwsSTSManager awsSTSManager;
 
     // elasticsearch
     @Autowired
@@ -162,5 +171,21 @@ public abstract class IntegrationTestSupport {
         }
 
         return lines;
+    }
+
+    protected void uploadToSpecificResource(String bucket, String key, Credentials credentials) {
+
+        BasicSessionCredentials awsCredentials = new BasicSessionCredentials(credentials.accessKeyId(), credentials.secretAccessKey(), credentials.sessionToken());
+        AmazonS3Client amazonS3Client = (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withRegion("ap-northeast-2")
+                .build();
+
+        try {
+            amazonS3Client.putObject(bucket, key, "test");
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new S3UploadFail();
+        }
     }
 }

--- a/src/test/java/swm/s3/coclimb/api/adapter/in/web/media/MediaControllerTest.java
+++ b/src/test/java/swm/s3/coclimb/api/adapter/in/web/media/MediaControllerTest.java
@@ -4,10 +4,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import software.amazon.awssdk.services.sts.model.Credentials;
 import swm.s3.coclimb.api.ControllerTestSupport;
 import swm.s3.coclimb.api.adapter.in.web.media.dto.MediaCreateProblemInfo;
 import swm.s3.coclimb.api.adapter.in.web.media.dto.MediaCreateRequest;
 import swm.s3.coclimb.api.adapter.in.web.media.dto.MediaUpdateRequest;
+import swm.s3.coclimb.api.application.port.out.aws.dto.S3AccessToken;
 import swm.s3.coclimb.domain.media.InstagramMediaInfo;
 import swm.s3.coclimb.domain.media.Media;
 import swm.s3.coclimb.domain.media.MediaProblemInfo;
@@ -144,5 +146,36 @@ class MediaControllerTest extends ControllerTestSupport {
                                         .build())))
                 .andExpect(status().isNoContent());
         then(mediaCommand).should(times(1)).updateMedia(any());
+    }
+
+    @Test
+    @DisplayName("미디어 접근을 위한 엑세스 토큰을 획득한다.")
+    void getMediaAccessToken() throws Exception {
+        // given
+        String accessToken = "token";
+        given(jwtManager.getSubject(accessToken)).willReturn("1");
+        given(userLoadPort.getById(1L)).willReturn(User.builder()
+                .name("username")
+                .instagramUserInfo(InstagramUserInfo.builder().build())
+                .build());
+        S3AccessToken s3AccessToken = S3AccessToken.of("bucket",
+                "key",
+                Credentials.builder()
+                        .accessKeyId("ac")
+                        .secretAccessKey("sc")
+                        .sessionToken("st")
+                        .build());
+
+        given(mediaCommand.createTokenForUpload(any(), any(), any())).willReturn(s3AccessToken);
+
+        // when, then
+        mockMvc.perform(get("/medias/access-token")
+                .header("Authorization", accessToken))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.accessKey").value("ac"))
+                .andExpect(jsonPath("$.secretKey").value("sc"))
+                .andExpect(jsonPath("$.sessionToken").value("st"))
+                .andExpect(jsonPath("$.bucket").value("bucket"))
+                .andExpect(jsonPath("$.key").value("key"));
     }
 }

--- a/src/test/java/swm/s3/coclimb/api/adapter/out/aws/AwsSTSManagerTest.java
+++ b/src/test/java/swm/s3/coclimb/api/adapter/out/aws/AwsSTSManagerTest.java
@@ -18,10 +18,10 @@ class AwsSTSManagerTest extends IntegrationTestSupport {
         Long userId = 1L;
         String bucket = "coclimb-media-bucket";
         String prefix = "test";
+        String action = "PutObject";
         String key = awsSTSManager.generateKey(prefix, userId);
-        String policy = awsSTSManager.generatePolicy(bucket, key, "PutObject");
         // when
-        Credentials sut = awsSTSManager.getUploadCredentials(policy);
+        Credentials sut = awsSTSManager.getCredentials(bucket, key, action);
 
         // then
         assertThat(sut).isNotNull();
@@ -38,9 +38,10 @@ class AwsSTSManagerTest extends IntegrationTestSupport {
         String bucket = "coclimb-media-bucket";
         String prefix = "test";
         String key = awsSTSManager.generateKey(prefix, userId);
-        String policy = awsSTSManager.generatePolicy(bucket, key, "PutObject");
+        String action = "PutObject";
+
         // when
-        Credentials sut = awsSTSManager.getUploadCredentials(policy);
+        Credentials sut = awsSTSManager.getCredentials(bucket,key,action);
 
         // then
         assertThat(sut).isNotNull();

--- a/src/test/java/swm/s3/coclimb/api/adapter/out/aws/AwsSTSManagerTest.java
+++ b/src/test/java/swm/s3/coclimb/api/adapter/out/aws/AwsSTSManagerTest.java
@@ -1,0 +1,51 @@
+package swm.s3.coclimb.api.adapter.out.aws;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import swm.s3.coclimb.api.IntegrationTestSupport;
+import swm.s3.coclimb.api.exception.errortype.aws.S3UploadFail;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AwsSTSManagerTest extends IntegrationTestSupport {
+
+    @Test
+    @DisplayName("특정 리소스에만 접근 가능한 임시 권한을 획득한다.")
+    void getTempAuthToken() throws Exception {
+        // given
+        Long userId = 1L;
+        String bucket = "coclimb-media-bucket";
+        String prefix = "test";
+        String key = awsSTSManager.generateKey(prefix, userId);
+        String policy = awsSTSManager.generatePolicy(bucket, key, "PutObject");
+        // when
+        Credentials sut = awsSTSManager.getUploadCredentials(policy);
+
+        // then
+        assertThat(sut).isNotNull();
+        Assertions.assertThatCode(() ->
+                uploadToSpecificResource(bucket, key, sut)).doesNotThrowAnyException();
+    }
+
+
+    @Test
+    @DisplayName("권한이 없는 리소스에 접근 시 예외가 발생한다.")
+    void uploadByUnauthorizedToken() throws Exception {
+        // given
+        Long userId = 1L;
+        String bucket = "coclimb-media-bucket";
+        String prefix = "test";
+        String key = awsSTSManager.generateKey(prefix, userId);
+        String policy = awsSTSManager.generatePolicy(bucket, key, "PutObject");
+        // when
+        Credentials sut = awsSTSManager.getUploadCredentials(policy);
+
+        // then
+        assertThat(sut).isNotNull();
+        Assertions.assertThatThrownBy(() ->
+                uploadToSpecificResource(bucket, key+"unauthorized", sut)).isInstanceOf(S3UploadFail.class);
+    }
+
+}

--- a/src/test/java/swm/s3/coclimb/api/application/service/MediaServiceTest.java
+++ b/src/test/java/swm/s3/coclimb/api/application/service/MediaServiceTest.java
@@ -1,5 +1,6 @@
 package swm.s3.coclimb.api.application.service;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -14,6 +15,7 @@ import swm.s3.coclimb.api.application.port.in.media.dto.MediaCreateRequestDto;
 import swm.s3.coclimb.api.application.port.in.media.dto.MediaDeleteRequestDto;
 import swm.s3.coclimb.api.application.port.in.media.dto.MediaPageRequestDto;
 import swm.s3.coclimb.api.application.port.in.media.dto.MediaUpdateRequestDto;
+import swm.s3.coclimb.api.application.port.out.aws.dto.S3AccessToken;
 import swm.s3.coclimb.api.application.port.out.filedownload.DownloadedFileDetail;
 import swm.s3.coclimb.api.exception.errortype.media.InstagramMediaIdConflict;
 import swm.s3.coclimb.domain.media.InstagramMediaInfo;
@@ -332,4 +334,22 @@ class MediaServiceTest extends IntegrationTestSupport {
                 .extracting("user.name", "mediaProblemInfo.gymName")
                 .containsOnly(tuple(userName2, gymName2));
     }
+
+    @Test
+    @DisplayName("특정 S3 리소스에 미디어 업로드가 가능한 임시 접근 권한을 생성한다.")
+    void createTokenForUpload() throws Exception {
+        // given
+        Long userId = 1L;
+        String bucket = "coclimb-media-bucket";
+        String prefix = "test";
+
+        // when
+        S3AccessToken sut = mediaService.createTokenForUpload(bucket, prefix, userId);
+
+        // then
+        assertThat(sut).isNotNull();
+        Assertions.assertThatCode(() ->
+                uploadToSpecificResource(bucket, sut.getKey(), sut.getCredentials())).doesNotThrowAnyException();
+    }
+
 }

--- a/src/test/java/swm/s3/coclimb/api/application/service/MediaServiceTest.java
+++ b/src/test/java/swm/s3/coclimb/api/application/service/MediaServiceTest.java
@@ -342,9 +342,10 @@ class MediaServiceTest extends IntegrationTestSupport {
         Long userId = 1L;
         String bucket = "coclimb-media-bucket";
         String prefix = "test";
+        String action = "PutObject";
 
         // when
-        S3AccessToken sut = mediaService.createTokenForUpload(bucket, prefix, userId);
+        S3AccessToken sut = mediaService.createS3AccessToken(bucket, prefix, userId,action);
 
         // then
         assertThat(sut).isNotNull();


### PR DESCRIPTION
## 관련 이슈 or 작업
- 번호 : #93-task-2, 3<!---- 이슈 : #1, 작업 : task-1 -->

- 노션 링크 : https://piquant-asterisk-eba.notion.site/task-2-_-_API-7734aef46cdd4386ac5183801a751a09?pvs=4
- 
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
S3 임시 접근 권한을 획득하는 API를 구현하였습니다.
- 특정 Bucket의 특정 key에만 접근 가능한 Inline Policy를 동적으로 생성합니다.
- 생성된 Policy를 사용해 특정 리소스(bucket, key)에 대해서만 접근 가능한 임시 접근 권한을 생성합니다.
- 임시 접근 권한과 해당 권한으로 접근 가능한 리소스(bucket, key)를 반환합니다.

미디어 API를 리팩토링 하였습니다.
- task2에서 구현한 API를 일부 수정하였습니다.
- 기존 미디어 생성 API에서 파일을 다운로드 받고 s3에 업로드를 하는 로직을 제거하였습니다.
- 제거한 로직 대신 클라이언트에게 전달받은 업로드 완료된 url을 cloudfront 주소와 함께 DB에 저장하도록 수정하였습니다.

## PR 유형
변경 사항을 체크해주세요.

- [x] 새로운 기능 추가
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 코드 리팩토링
- [ ] 인프라 관련 파일 추가(dockerfile 등)
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 추가 및 수정
- [x] 파일명 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 패키지 구조 변경
- [ ] 버그 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- 참고 : https://piquant-asterisk-eba.notion.site/Commit-Convention-c359c4de15d3442ea7b1ef8a6ad30cbd?pvs=4
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
